### PR TITLE
Fix possessive forms being converted to feet (issue #16)

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -741,7 +741,10 @@ function convertLengthText(text) {
     // Handle standalone inch/foot symbols like 12" or 5' including hyphenated mixed fractions like 12-1/2"
     const VALUE_PART = String.raw`(?:(?:\d{1,3}(?:,\d{3})+|\d+)\.\d+|(?:\d{1,3}(?:,\d{3})+|\d+)-\d+\/\d+|(?:\d{1,3}(?:,\d{3})+|\d+)\s+\d+\/\d+|\d+\/\d+|(?:\d{1,3}(?:,\d{3})+|\d+)[${UNICODE_FRACTIONS}]?|[${UNICODE_FRACTIONS}])`;
     const inchesSymbolRegex = new RegExp(String.raw`(${VALUE_PART})\s*(?:"|″|”)(?!\s*\()`, 'giu');
-    const feetSymbolRegex = new RegExp(String.raw`(${VALUE_PART})\s*(?:'|′|’)(?!\s*\()`, 'giu');
+    const feetSymbolRegex = new RegExp(
+        String.raw`(${VALUE_PART})\s*(?:'|′|’)(?!\s*\()(?!s)`,
+        'giu'
+    );
 
     if (converted.includes('"') || converted.includes('″') || converted.includes('”')) {
         converted = converted.replace(inchesSymbolRegex, function () {

--- a/test/content.test.js
+++ b/test/content.test.js
@@ -371,6 +371,29 @@ describe('Unit Conversion Tests', () => {
                 expect(document.body.textContent).toBe(expected);
             });
         });
+
+        test('does not convert possessive forms with apostrophe-s', () => {
+            const possessiveCases = [
+                {
+                    input: "1950's Vintage Autoette Electric Golf Cart with cassette player.",
+                    expected: "1950's Vintage Autoette Electric Golf Cart with cassette player.",
+                },
+                {
+                    input: "The 1980's fashion trends are coming back.",
+                    expected: "The 1980's fashion trends are coming back.",
+                },
+                {
+                    input: "My car's 2020's model year is impressive.",
+                    expected: "My car's 2020's model year is impressive.",
+                },
+            ];
+
+            possessiveCases.forEach(({ input, expected }) => {
+                document.body.textContent = input;
+                processNode(document.body);
+                expect(document.body.textContent).toBe(expected);
+            });
+        });
     });
 
     describe('MutationObserver', () => {


### PR DESCRIPTION
## Summary
- Fixed issue where possessive forms like "1950's" were incorrectly converted to feet measurements
- Added negative lookahead `(?!s)` to the `feetSymbolRegex` to exclude apostrophe + 's' patterns
- Added comprehensive test cases to verify the fix

## Changes
- Modified `src/content.js:744` - Added `(?!s)` negative lookahead to prevent matching possessive forms
- Added test cases in `test/content.test.js` to verify possessive forms are not converted

## Test Cases
The new test verifies that these patterns are NOT converted:
- `1950's Vintage Autoette Electric Golf Cart with cassette player.`
- `The 1980's fashion trends are coming back.`
- `My car's 2020's model year is impressive.`

While ensuring existing functionality still works (e.g., `6' stretch` correctly converts to `6' (1.83 m) stretch`).

## Test Results
All 137 tests pass ✓

Fixes #16