### PR TITLE
Fix negative Fahrenheit temperature conversions (issue #10)

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -176,7 +176,7 @@ function buildUnitDataFromSpecs(specs) {
     return { UNITS: units, UNIT_HINT_PATTERN: hintPattern };
 }
 
-const TEMPERATURE_F_REGEX = String.raw`(?<!\()(?<![\d.])\b(\d+(?:\.\d+)?)\s*(?:°\s*F|℉|F\b|deg\s*F|degree\s*F|degrees\s*F|degrees?\s*Fahrenheit|Fahrenheit)\b(?!\s*\()`;
+const TEMPERATURE_F_REGEX = String.raw`(?<!\()(?<![\d.])(?<![–—])(-?\d+(?:\.\d+)?)\s*(?:°\s*F|℉|F\b|deg\s*F|degree\s*F|degrees\s*F|degrees?\s*Fahrenheit|Fahrenheit)\b(?!\s*\()`;
 
 // Precompiled temperature regexes
 const RE_TEMPERATURE_F = new RegExp(TEMPERATURE_F_REGEX, 'gi');

--- a/test/content.test.js
+++ b/test/content.test.js
@@ -7,6 +7,7 @@ const {
     createRegexFromTemplate,
     convertWeightText,
     parseMeasurementMatch,
+    convertTemperatureText,
 } = require('../src/content.js');
 
 describe('Basic Regex Tests', () => {
@@ -1275,6 +1276,70 @@ describe('Time Zone Conversion Tests', () => {
                 document.body.textContent = input;
                 processNode(document.body);
                 expect(document.body.textContent).toBe(expected);
+            });
+        });
+    });
+});
+
+describe('Temperature Conversion Tests', () => {
+    describe('Fahrenheit to Celsius Conversions', () => {
+        test('converts positive Fahrenheit temperatures', () => {
+            const positiveCases = [
+                { input: '32°F', expected: '32°F (0.00°C)' },
+                { input: '212°F', expected: '212°F (100°C)' },
+                { input: '70°F', expected: '70°F (21.1°C)' },
+                { input: '98.6°F', expected: '98.6°F (37.0°C)' },
+            ];
+
+            positiveCases.forEach(({ input, expected }) => {
+                const result = convertTemperatureText(input);
+                expect(result).toBe(expected);
+            });
+        });
+
+        test('converts negative Fahrenheit temperatures (issue #10)', () => {
+            const negativeCases = [
+                { input: '-40°F', expected: '-40°F (-40.0°C)' },
+                { input: '-10°F', expected: '-10°F (-23.3°C)' },
+                { input: '-4°F', expected: '-4°F (-20.0°C)' },
+                { input: '0°F', expected: '0°F (-17.8°C)' },
+            ];
+
+            negativeCases.forEach(({ input, expected }) => {
+                const result = convertTemperatureText(input);
+                expect(result).toBe(expected);
+            });
+        });
+
+        test('converts temperature ranges with negative values', () => {
+            const rangeCases = [
+                {
+                    input: '-40°F to 140°F',
+                    expected: '-40°F (-40.0°C) to 140°F (60.0°C)',
+                },
+                {
+                    input: 'Temperature from -10°F to 32°F',
+                    expected: 'Temperature from -10°F (-23.3°C) to 32°F (0.00°C)',
+                },
+            ];
+
+            rangeCases.forEach(({ input, expected }) => {
+                const result = convertTemperatureText(input);
+                expect(result).toBe(expected);
+            });
+        });
+
+        test('handles various Fahrenheit notations', () => {
+            const notationCases = [
+                { input: '32 F', expected: '32 F (0.00°C)' },
+                { input: '100 degrees F', expected: '100 degrees F (37.8°C)' },
+                { input: '72 deg F', expected: '72 deg F (22.2°C)' },
+                { input: '50 Fahrenheit', expected: '50 Fahrenheit (10.0°C)' },
+            ];
+
+            notationCases.forEach(({ input, expected }) => {
+                const result = convertTemperatureText(input);
+                expect(result).toBe(expected);
             });
         });
     });


### PR DESCRIPTION
## Summary

Fixes issue #10 where negative Fahrenheit temperatures were not being converted correctly.

### Problem
The temperature conversion regex pattern was not capturing the minus sign, causing negative temperatures to be incorrectly converted:
- **Before**: `-40°F (4.44°C)` ❌
- **After**: `-40°F (-40.0°C)` ✅

### Changes Made

1. **Updated regex pattern** in `src/content.js`:
   - Changed `(\d+(?:\.\d+)?)` to `(-?\d+(?:\.\d+)?)` to capture optional minus sign
   - Added negative lookbehind `(?<![–—])` for em/en dashes to prevent false matches
   - Removed redundant `\b` word boundary that was incompatible with minus sign

2. **Added comprehensive temperature conversion tests** in `test/content.test.js`:
   - Positive temperature conversions (32°F, 212°F, 70°F, 98.6°F)
   - Negative temperature conversions (-40°F, -10°F, -4°F, 0°F)
   - Temperature ranges with negative values (-40°F to 140°F)
   - Various Fahrenheit notation formats (F, deg F, degrees F, Fahrenheit)

### Test Results

All tests pass (142 tests total):
- ✅ 4 new temperature conversion tests
- ✅ All existing tests continue to pass
- ✅ No regressions detected

### Examples

- `-40°F` → `-40°F (-40.0°C)` (the famous -40 convergence point!)
- `-10°F` → `-10°F (-23.3°C)`
- `0°F` → `0°F (-17.8°C)`
- `-40°F to 140°F` → `-40°F (-40.0°C) to 140°F (60.0°C)`

Closes #10