### PR TITLE
Performance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,10 @@ on:
         branches:
             - '**'
 
+permissions:
+    contents: read
+    pull-requests: write
+
 jobs:
     test:
         runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,9 +34,26 @@ jobs:
             - name: Run linting
               run: npm run lint
 
-    performance:
+    check-src-changes:
         runs-on: ubuntu-latest
         if: github.event_name == 'pull_request'
+        outputs:
+            src_changed: ${{ steps.changes.outputs.src }}
+        steps:
+            - uses: actions/checkout@v3
+            - uses: dorny/paths-filter@v3
+              id: changes
+              with:
+                  filters: |
+                      src:
+                        - 'src/**'
+                        - 'scripts/perf-compare.js'
+                        - 'test/performance.test.js'
+
+    performance:
+        runs-on: ubuntu-latest
+        needs: check-src-changes
+        if: github.event_name == 'pull_request' && needs.check-src-changes.outputs.src_changed == 'true'
 
         steps:
             - name: Checkout PR branch

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,3 +29,108 @@ jobs:
 
             - name: Run linting
               run: npm run lint
+
+    performance:
+        runs-on: ubuntu-latest
+        if: github.event_name == 'pull_request'
+
+        steps:
+            - name: Checkout PR branch
+              uses: actions/checkout@v3
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v3
+              with:
+                  node-version: '18'
+                  cache: 'npm'
+
+            - name: Install dependencies
+              run: npm ci
+
+            - name: Run performance benchmark on PR
+              id: pr-perf
+              run: |
+                  result=$(node scripts/perf-compare.js)
+                  echo "$result"
+                  avg=$(echo "$result" | jq -r '.average')
+                  echo "pr_avg=$avg" >> $GITHUB_OUTPUT
+
+            - name: Checkout base branch
+              uses: actions/checkout@v3
+              with:
+                  ref: ${{ github.event.pull_request.base.ref }}
+                  clean: false
+
+            - name: Install dependencies (base)
+              run: npm ci
+
+            - name: Run performance benchmark on base
+              id: base-perf
+              run: |
+                  result=$(node scripts/perf-compare.js)
+                  echo "$result"
+                  avg=$(echo "$result" | jq -r '.average')
+                  echo "base_avg=$avg" >> $GITHUB_OUTPUT
+
+            - name: Checkout PR branch again for comparison
+              uses: actions/checkout@v3
+
+            - name: Install dependencies (PR)
+              run: npm ci
+
+            - name: Compare performance
+              run: |
+                  echo "Base branch average: ${{ steps.base-perf.outputs.base_avg }} ms"
+                  echo "PR branch average: ${{ steps.pr-perf.outputs.pr_avg }} ms"
+                  node scripts/perf-compare.js --baseline ${{ steps.base-perf.outputs.base_avg }} --threshold 5
+
+            - name: Post performance results
+              if: always()
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const baseAvg = '${{ steps.base-perf.outputs.base_avg }}';
+                      const prAvg = '${{ steps.pr-perf.outputs.pr_avg }}';
+                      const change = ((prAvg - baseAvg) / baseAvg * 100).toFixed(2);
+                      const passed = change <= 5;
+                      const emoji = passed ? '✅' : '❌';
+                      const status = passed ? 'PASSED' : 'FAILED';
+
+                      const body = `## ${emoji} Performance Test ${status}
+
+                      | Metric | Value |
+                      |--------|-------|
+                      | Base branch (${context.payload.pull_request.base.ref}) | ${baseAvg} ms |
+                      | PR branch | ${prAvg} ms |
+                      | Change | ${change}% |
+                      | Threshold | 5% |
+
+                      ${!passed ? '⚠️ **Performance regression detected!** The PR is more than 5% slower than the base branch.' : '👍 Performance is within acceptable limits.'}
+                      `;
+
+                      // Find existing comment
+                      const { data: comments } = await github.rest.issues.listComments({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          issue_number: context.payload.pull_request.number,
+                      });
+
+                      const botComment = comments.find(c =>
+                          c.user.type === 'Bot' && c.body.includes('Performance Test')
+                      );
+
+                      if (botComment) {
+                          await github.rest.issues.updateComment({
+                              owner: context.repo.owner,
+                              repo: context.repo.repo,
+                              comment_id: botComment.id,
+                              body: body
+                          });
+                      } else {
+                          await github.rest.issues.createComment({
+                              owner: context.repo.owner,
+                              repo: context.repo.repo,
+                              issue_number: context.payload.pull_request.number,
+                              body: body
+                          });
+                      }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@
     - **Gate in `src/converter.js`** before calling the converter (cheap hint check like `HINT_RE.test(text)`); do not call `convert<Unit>Text()` unconditionally.
     - **Gate inside `src/units/<unit>.js`** at the top of `convert<Unit>Text()` as a defensive early-exit (covers direct calls and future refactors).
 - Important footgun: `String.prototype.replace()` with a global regex still scans the whole string even when there are zero matches (the callback simply never runs). Always add a cheap presence hint before running expensive regex conversions.
+- Range merging is especially expensive because it can scan the same string multiple times (once per unit variant). Always add unit-specific hint gates before calling `mergeUnitRanges()` (see the `RANGE_*_HINT_RE` pattern in `src/converter.js`).
 - After adding a unit, run `npm test`, `npm run lint`, and re-check perf with `node scripts/run-perf.js` to catch regressions early.
 
 ## Testing Guidelines

--- a/scripts/perf-compare.js
+++ b/scripts/perf-compare.js
@@ -86,7 +86,9 @@ function main() {
             console.error(`Baseline: ${baseline.toFixed(2)} ms, Current: ${avg.toFixed(2)} ms`);
             process.exit(1);
         } else {
-            console.log(`\nPerformance check passed: ${changePercent.toFixed(2)}% change (threshold: ${threshold}%)`);
+            console.log(
+                `\nPerformance check passed: ${changePercent.toFixed(2)}% change (threshold: ${threshold}%)`
+            );
         }
     } else {
         // Just output the benchmark result

--- a/scripts/perf-compare.js
+++ b/scripts/perf-compare.js
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+/**
+ * Performance comparison script for CI.
+ * Runs performance tests multiple times and outputs JSON results.
+ * Can compare against a baseline and fail if regression exceeds threshold.
+ *
+ * Usage:
+ *   node scripts/perf-compare.js                    # Run benchmark, output JSON
+ *   node scripts/perf-compare.js --baseline 50.0    # Compare against baseline
+ *   node scripts/perf-compare.js --threshold 5      # Set threshold % (default: 5)
+ */
+const { spawnSync } = require('child_process');
+
+const RUNS = 5;
+const DEFAULT_THRESHOLD_PERCENT = 5;
+
+function runOnce() {
+    const res = spawnSync('npx', ['jest', 'test/performance.test.js', '--runInBand'], {
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    if (res.error) throw res.error;
+    const out = (res.stdout || '') + (res.stderr || '');
+    const m = out.match(/processNode on recipe\.html: ([0-9]+\.[0-9]+) ms/);
+    if (!m) {
+        throw new Error('Could not parse performance output. Output was:\n' + out);
+    }
+    return parseFloat(m[1]);
+}
+
+function parseArgs() {
+    const args = process.argv.slice(2);
+    const result = { baseline: null, threshold: DEFAULT_THRESHOLD_PERCENT };
+
+    for (let i = 0; i < args.length; i++) {
+        if (args[i] === '--baseline' && args[i + 1]) {
+            result.baseline = parseFloat(args[i + 1]);
+            i++;
+        } else if (args[i] === '--threshold' && args[i + 1]) {
+            result.threshold = parseFloat(args[i + 1]);
+            i++;
+        }
+    }
+    return result;
+}
+
+function main() {
+    const { baseline, threshold } = parseArgs();
+    const times = [];
+
+    // Run benchmark multiple times
+    for (let i = 0; i < RUNS; i++) {
+        const t = runOnce();
+        times.push(t);
+    }
+
+    // Calculate statistics
+    const sorted = [...times].sort((a, b) => a - b);
+    const avg = times.reduce((a, b) => a + b, 0) / RUNS;
+    const median = sorted[Math.floor(RUNS / 2)];
+    const min = sorted[0];
+    const max = sorted[RUNS - 1];
+
+    const result = {
+        runs: times,
+        average: parseFloat(avg.toFixed(2)),
+        median: parseFloat(median.toFixed(2)),
+        min: parseFloat(min.toFixed(2)),
+        max: parseFloat(max.toFixed(2)),
+    };
+
+    // If baseline provided, compare
+    if (baseline !== null) {
+        const changePercent = ((avg - baseline) / baseline) * 100;
+        result.baseline = baseline;
+        result.changePercent = parseFloat(changePercent.toFixed(2));
+        result.threshold = threshold;
+        result.passed = changePercent <= threshold;
+
+        console.log(JSON.stringify(result, null, 2));
+
+        if (!result.passed) {
+            console.error(
+                `\nPerformance regression detected: ${changePercent.toFixed(2)}% slower (threshold: ${threshold}%)`
+            );
+            console.error(`Baseline: ${baseline.toFixed(2)} ms, Current: ${avg.toFixed(2)} ms`);
+            process.exit(1);
+        } else {
+            console.log(`\nPerformance check passed: ${changePercent.toFixed(2)}% change (threshold: ${threshold}%)`);
+        }
+    } else {
+        // Just output the benchmark result
+        console.log(JSON.stringify(result, null, 2));
+    }
+}
+
+main();

--- a/scripts/perf-compare.js
+++ b/scripts/perf-compare.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* eslint-disable no-console */
 /**
  * Performance comparison script for CI.
  * Runs performance tests multiple times and outputs JSON results.
@@ -86,7 +87,9 @@ function main() {
             console.error(`Baseline: ${baseline.toFixed(2)} ms, Current: ${avg.toFixed(2)} ms`);
             process.exit(1);
         } else {
-            console.log(`\nPerformance check passed: ${changePercent.toFixed(2)}% change (threshold: ${threshold}%)`);
+            console.log(
+                `\nPerformance check passed: ${changePercent.toFixed(2)}% change (threshold: ${threshold}%)`
+            );
         }
     } else {
         // Just output the benchmark result

--- a/src/content.js
+++ b/src/content.js
@@ -74,9 +74,12 @@ const {
     TARGET_TIMEZONE,
     TARGET_TIMEZONE_OFFSET,
 } = require('./units/timezone.js');
-const { convertText, hasRelevantUnits } = require('./converter.js');
+const { convertText, convertTextWithInsertMarkers, hasRelevantUnits } = require('./converter.js');
 const exclusionContext = require('./exclusions/context.js');
 const { shouldExcludeMatch } = require('./exclusions/patterns.js');
+const { INSERT_START, INSERT_END, stripInsertMarkers } = require('./utils/insertMarkers.js');
+
+const WHITESPACE_ONLY_RE = /^\s*$/;
 
 function buildUnitDataFromSpecs(specs) {
     const hintPieces = new Set();
@@ -159,6 +162,34 @@ function getPluginName() {
     return 'Imperial to Metric';
 }
 
+let cachedPluginName = null;
+function getCachedPluginName() {
+    if (cachedPluginName) return cachedPluginName;
+    cachedPluginName = getPluginName();
+    return cachedPluginName;
+}
+
+const styledDocs = typeof WeakSet !== 'undefined' ? new WeakSet() : null;
+function ensureInsertedStyles(doc) {
+    if (!doc) return;
+    if (styledDocs && styledDocs.has(doc)) return;
+    if (doc.getElementById && doc.getElementById('mic-inserted-style')) {
+        if (styledDocs) styledDocs.add(doc);
+        return;
+    }
+
+    const style = doc.createElement ? doc.createElement('style') : null;
+    if (!style) return;
+    style.id = 'mic-inserted-style';
+    style.textContent = `.mic-inserted {\n  text-decoration-line: underline !important;\n  text-decoration-style: dotted !important;\n  text-decoration-color: currentColor !important;\n}`;
+
+    const parent = doc.head || doc.documentElement || doc.body;
+    if (parent && parent.appendChild) {
+        parent.appendChild(style);
+        if (styledDocs) styledDocs.add(doc);
+    }
+}
+
 // Helper to style inserted conversions with underline + tooltip
 function createInsertedSpan(text, doc) {
     const d = doc || (typeof document !== 'undefined' ? document : null);
@@ -177,12 +208,8 @@ function createInsertedSpan(text, doc) {
               },
           };
     span.className = 'mic-inserted';
-    // Inline styles to avoid relying on site CSS
-    span.style.textDecorationLine = 'underline';
-    span.style.textDecorationStyle = 'dotted';
-    // Match underline color to surrounding text color
-    span.style.textDecorationColor = 'currentColor';
-    span.title = `Inserted by ${getPluginName()} extension`;
+    ensureInsertedStyles(d);
+    span.title = `Inserted by ${getCachedPluginName()} extension`;
     span.textContent = text;
     return span;
 }
@@ -198,14 +225,19 @@ function processElement(node) {
 
     function processTextNode(textNode) {
         if (!textNode || textNode.nodeType !== Node.TEXT_NODE) return;
-        const originalText = textNode.textContent;
+        const originalText = textNode.nodeValue;
+
+        // Skip text nodes that do not contain relevant number+unit hints
+        if (!hasRelevantUnits(originalText)) {
+            return;
+        }
 
         // Fast pre-filter: only process text that might contain relevant units
         // Skip if the next significant sibling (ignoring whitespace-only text nodes)
         // is one of our inserted spans. This prevents double-processing the same
         // text node content after we've already added a following "(… )" span.
         let ns = textNode.nextSibling;
-        while (ns && ns.nodeType === Node.TEXT_NODE && /^\s*$/.test(ns.textContent)) {
+        while (ns && ns.nodeType === Node.TEXT_NODE && WHITESPACE_ONLY_RE.test(ns.nodeValue)) {
             ns = ns.nextSibling;
         }
         if (
@@ -217,88 +249,70 @@ function processElement(node) {
             return;
         }
 
-        // Skip text nodes that do not contain relevant number+unit hints
-        if (!hasRelevantUnits(originalText)) {
+        const markedText = convertTextWithInsertMarkers(originalText);
+        if (originalText === markedText) {
             return;
         }
 
-        const newText = convertText(originalText);
-        if (originalText === newText) {
-            return;
-        }
-
-        // Build a fragment that preserves original text and wraps inserted
-        // conversions like " (12.7 cm)" in a styled span.
+        // Build a fragment that preserves text and wraps inserted conversions
+        // like " (12.7 cm)" in a styled span.
         const doc =
             (textNode && textNode.ownerDocument) ||
             (typeof document !== 'undefined' ? document : null);
         const frag = doc ? doc.createDocumentFragment() : null;
-        let i = 0; // index in originalText
-        let j = 0; // index in newText
-        let buffer = '';
-
-        const isWhitespace = (ch) => /\s/.test(ch || '');
-
-        while (j < newText.length) {
-            if (i < originalText.length && originalText[i] === newText[j]) {
-                buffer += newText[j];
-                i += 1;
-                j += 1;
-                continue;
-            }
-
-            // Mismatch indicates inserted conversion. We expect optional whitespace then "(… )".
-            if (newText[j] === '(' || (isWhitespace(newText[j]) && newText[j + 1] === '(')) {
-                // Flush buffered matching text
-                if (buffer && frag && doc) {
-                    frag.appendChild(doc.createTextNode(buffer));
-                    buffer = '';
-                }
-
-                // If there is leading whitespace before '(', append it as plain text
-                while (isWhitespace(newText[j]) && newText[j + 1] === '(') {
-                    if (frag && doc) frag.appendChild(doc.createTextNode(newText[j]));
-                    j += 1;
-                }
-
-                // Now newText[j] should be '('
-                if (newText[j] !== '(') {
-                    // Not our pattern; fallback
-                    buffer += newText[j];
-                    j += 1;
-                    continue;
-                }
-
-                // Find the end of the inserted parenthetical
-                const closeIdx = newText.indexOf(')', j + 1);
-                if (closeIdx === -1) {
-                    // Fallback: no closing paren; append the rest as text
-                    buffer += newText.slice(j);
-                    break;
-                }
-                const insertedText = newText.slice(j, closeIdx + 1);
-                if (frag) {
-                    frag.appendChild(createInsertedSpan(insertedText, doc));
-                }
-                // Advance j past the inserted text; i stays the same
-                j = closeIdx + 1;
-                continue;
-            }
-
-            // Fallback: if not a recognized insertion, move forward conservatively
-            buffer += newText[j];
-            j += 1;
-        }
-
-        if (buffer && frag && doc) {
-            frag.appendChild(doc.createTextNode(buffer));
-        }
-        if (frag) {
-            textNode.replaceWith(frag);
-        } else {
+        if (!frag || !doc) {
             // Extremely defensive fallback for non-browser contexts
-            textNode.textContent = newText;
+            textNode.nodeValue = stripInsertMarkers(markedText);
+            return;
         }
+
+        const startMarker = INSERT_START;
+        const endMarker = INSERT_END;
+        let pos = 0;
+
+        let startIdx;
+        while ((startIdx = markedText.indexOf(startMarker, pos)) !== -1) {
+            const endIdx = markedText.indexOf(endMarker, startIdx + 1);
+            if (endIdx === -1) {
+                // Should not happen; fall back to plain text without markers
+                frag.appendChild(doc.createTextNode(stripInsertMarkers(markedText.slice(pos))));
+                pos = markedText.length;
+                break;
+            }
+
+            const openParenIdx = startIdx - 1;
+            const closeParenIdx = endIdx + 1;
+            if (
+                openParenIdx < pos ||
+                markedText[openParenIdx] !== '(' ||
+                closeParenIdx >= markedText.length ||
+                markedText[closeParenIdx] !== ')'
+            ) {
+                // Unexpected marker placement; fall back to plain text without markers
+                frag.appendChild(doc.createTextNode(stripInsertMarkers(markedText.slice(pos))));
+                pos = markedText.length;
+                break;
+            }
+
+            const before = markedText.slice(pos, openParenIdx);
+            if (before) {
+                frag.appendChild(doc.createTextNode(before));
+            }
+
+            const insertedContent = markedText.slice(startIdx + 1, endIdx);
+            frag.appendChild(createInsertedSpan(`(${insertedContent})`, doc));
+
+            pos = closeParenIdx + 1;
+        }
+
+        if (pos < markedText.length) {
+            const tail = markedText.slice(pos);
+            if (tail) {
+                frag.appendChild(doc.createTextNode(tail));
+            }
+        }
+
+        textNode.replaceWith(frag);
     }
 
     if (!node) return;
@@ -312,27 +326,29 @@ function processElement(node) {
         return;
     }
 
+    let current = node.firstChild;
     const stack = [];
-    for (let i = node.childNodes.length - 1; i >= 0; i--) {
-        stack.push(node.childNodes[i]);
-    }
 
-    while (stack.length) {
-        const current = stack.pop();
-        if (!current) continue;
-
+    while (current) {
         if (current.nodeType === Node.ELEMENT_NODE) {
             if (exclusionContext.isExcludedElement(current)) {
-                continue;
+                current = current.nextSibling;
+            } else if (current.firstChild) {
+                if (current.nextSibling) stack.push(current.nextSibling);
+                current = current.firstChild;
+            } else {
+                current = current.nextSibling;
             }
-            for (let i = current.childNodes.length - 1; i >= 0; i--) {
-                stack.push(current.childNodes[i]);
-            }
-            continue;
+        } else if (current.nodeType === Node.TEXT_NODE) {
+            const next = current.nextSibling;
+            processTextNode(current);
+            current = next;
+        } else {
+            current = current.nextSibling;
         }
 
-        if (current.nodeType === Node.TEXT_NODE) {
-            processTextNode(current);
+        while (!current && stack.length) {
+            current = stack.pop();
         }
     }
 }

--- a/src/converter.js
+++ b/src/converter.js
@@ -35,6 +35,7 @@ const {
     formatLiquidRange,
     formatTemperatureRange,
 } = require('./formatting/ranges.js');
+const { buildInsertedParenthetical } = require('./utils/insertMarkers.js');
 
 const FAST_NUMBER_HINT = new RegExp(String.raw`[0-9${UNICODE_FRACTIONS}]`, 'u');
 const RANGE_SEP_RE = /^(?:\s*)(?:-|–|—|to|through|thru)(?:\s*)$/i;
@@ -46,6 +47,40 @@ const VALUE_TAIL_RE = new RegExp(
 
 const QUOTE_LENGTH_HINT_RE = new RegExp(
     String.raw`(?:\d|[${UNICODE_FRACTIONS}])\s*[${INCH_SYMBOLS}${FEET_SYMBOLS}]`,
+    'iu'
+);
+
+// Range-merging unit hints to avoid running multiple full measurement scans
+const RANGE_LENGTH_FEET_INCHES_HINT_RE = new RegExp(
+    String.raw`(?:\bfeet\b|\bfoot\b|\bft\b|\binch(?:es)?\b|\b(?:\d|[${UNICODE_FRACTIONS}])\s*in\.?\b)`,
+    'iu'
+);
+const RANGE_LENGTH_MILES_HINT_RE = /\b(?:mi|miles?)\b/i;
+const RANGE_LENGTH_YARDS_HINT_RE = /\b(?:yd|yards?)\b/i;
+
+const RANGE_LIQUID_CUPS_HINT_RE = new RegExp(
+    String.raw`(?:\bcups?\b|\b(?:\d|[${UNICODE_FRACTIONS}])\s*c\b)`,
+    'iu'
+);
+const RANGE_LIQUID_GALLONS_HINT_RE = new RegExp(
+    String.raw`(?:\bgallons?\b|\b(?:\d|[${UNICODE_FRACTIONS}])\s*gal\b)`,
+    'iu'
+);
+const RANGE_LIQUID_QUARTS_HINT_RE = new RegExp(
+    String.raw`(?:\bquarts?\b|\b(?:\d|[${UNICODE_FRACTIONS}])\s*qt\b)`,
+    'iu'
+);
+const RANGE_LIQUID_PINTS_HINT_RE = new RegExp(
+    String.raw`(?:\bpints?\b|\b(?:\d|[${UNICODE_FRACTIONS}])\s*pt\b)`,
+    'iu'
+);
+const RANGE_LIQUID_FLOZ_HINT_RE = /(?:\bfluid\s+ounces?\b|\bfl\.?\s*oz\b)/i;
+const RANGE_LIQUID_TBSP_HINT_RE = new RegExp(
+    String.raw`(?:\btablespoons?\b|\b(?:\d|[${UNICODE_FRACTIONS}])\s*(?:tbsp|tbs|tb)\b)`,
+    'iu'
+);
+const RANGE_LIQUID_TSP_HINT_RE = new RegExp(
+    String.raw`(?:\bteaspoons?\b|\b(?:\d|[${UNICODE_FRACTIONS}])\s*(?:tsp|ts)\b)`,
     'iu'
 );
 
@@ -115,7 +150,7 @@ function applyReplacements(original, replacements) {
  * Expects a cached (global) regex; resets `lastIndex` before scanning.
  */
 function mergeUnitRanges(s, config) {
-    const { unitSpec, regex, converter, formatter, addPlaceholder } = config;
+    const { unitSpec, regex, converter, formatter, addPlaceholder, options } = config;
     const replacements = [];
 
     regex.lastIndex = 0;
@@ -141,7 +176,9 @@ function mergeUnitRanges(s, config) {
                 const val1 = converter(leftParsed);
                 const val2 = converter(rightParsed);
                 const formatted = formatter(val1, val2);
-                const token = addPlaceholder(`${s.slice(prev.start, curr.end)} (${formatted})`);
+                const token = addPlaceholder(
+                    `${s.slice(prev.start, curr.end)} ${buildInsertedParenthetical(formatted, options)}`
+                );
                 replacements.push({ start: prev.start, end: curr.end, token });
                 continue;
             }
@@ -174,7 +211,9 @@ function mergeUnitRanges(s, config) {
                     const val1 = converter(leftParsed);
                     const val2 = converter(rightParsed);
                     const formatted = formatter(val1, val2);
-                    const token = addPlaceholder(`${s.slice(tailStart, curr.end)} (${formatted})`);
+                    const token = addPlaceholder(
+                        `${s.slice(tailStart, curr.end)} ${buildInsertedParenthetical(formatted, options)}`
+                    );
                     replacements.push({ start: tailStart, end: curr.end, token });
                 }
             }
@@ -228,7 +267,6 @@ const LIQUID_CONVERTERS = {
  */
 // Lightweight numeric + unit hint to gate scanning for all units (abbrev + spelled-out)
 const FAST_NUMBER_HINT_GLOBAL = new RegExp(String.raw`[0-9${UNICODE_FRACTIONS}]`, 'u');
-const UNIT_HINT_GROUP = new RegExp(`(?:${UNIT_HINT_PATTERN})`, 'iu');
 const NUM_TOKEN_GROUP = (function () {
     const unicode = UNICODE_FRACTIONS;
     // decimal | mixed a b/c | simple a/b | unicode fraction | integer with thousands
@@ -236,8 +274,11 @@ const NUM_TOKEN_GROUP = (function () {
     return new RegExp(num, 'u');
 })();
 const RE_UNIT_NUM_HINT = (function () {
-    const num = NUM_TOKEN_GROUP.source;
-    const unit = UNIT_HINT_GROUP.source;
+    // Fast “number-ish” prefix (digits/fractions + separators) to avoid scanning whole strings
+    // with the full measurement regex. This is a hint only (high recall, reasonable precision).
+    const unicode = UNICODE_FRACTIONS;
+    const num = String.raw`[0-9${unicode}][0-9${unicode},./\s]{0,24}`;
+    const unit = String.raw`(?:${UNIT_HINT_PATTERN})`;
     return new RegExp(`(?:${num})\\s*(?:${unit})|(?:${unit})\\s*(?:${num})`, 'iu');
 })();
 const RE_INCH_SYMBOL_HINT = new RegExp(
@@ -248,11 +289,8 @@ const RE_INCH_SYMBOL_HINT = new RegExp(
 function hasRelevantUnits(text) {
     if (!text || typeof text !== 'string') return false;
 
-    // Quick exits: no digits or unicode fractions, and no temperature/time matches
+    // Quick exit: no digits or unicode fractions
     if (!FAST_NUMBER_HINT_GLOBAL.test(text)) {
-        // Temps and times always include digits in our patterns; keep checks anyway
-        if (RE_TEMPERATURE_F_TEST.test(text)) return true;
-        if (RE_TIME_TEST.test(text)) return true;
         return false;
     }
 
@@ -269,8 +307,7 @@ function hasRelevantUnits(text) {
     return false;
 }
 
-// Update the main convertText function to handle time zones
-function convertText(text) {
+function convertTextInternal(text, options = {}) {
     let converted = text;
 
     // Fast path: if there are no digits or unicode fractions, skip entirely
@@ -298,27 +335,36 @@ function convertText(text) {
     // Perform merges prior to standard conversions (only when relevant)
     if (RANGE_PRESENCE_RE.test(converted)) {
         if (hasLengthUnits) {
-            converted = mergeUnitRanges(converted, {
-                unitSpec: UNITS.LENGTH.FEET_INCHES,
-                regex: RANGE_REGEXES.feetInches,
-                converter: LENGTH_CONVERTERS.feetInches,
-                formatter: formatLengthRange,
-                addPlaceholder,
-            });
-            converted = mergeUnitRanges(converted, {
-                unitSpec: UNITS.LENGTH.MILES,
-                regex: RANGE_REGEXES.miles,
-                converter: LENGTH_CONVERTERS.miles,
-                formatter: formatLengthRange,
-                addPlaceholder,
-            });
-            converted = mergeUnitRanges(converted, {
-                unitSpec: UNITS.LENGTH.YARDS,
-                regex: RANGE_REGEXES.yards,
-                converter: LENGTH_CONVERTERS.yards,
-                formatter: formatLengthRange,
-                addPlaceholder,
-            });
+            if (quoteLengthHint || RANGE_LENGTH_FEET_INCHES_HINT_RE.test(converted)) {
+                converted = mergeUnitRanges(converted, {
+                    unitSpec: UNITS.LENGTH.FEET_INCHES,
+                    regex: RANGE_REGEXES.feetInches,
+                    converter: LENGTH_CONVERTERS.feetInches,
+                    formatter: formatLengthRange,
+                    addPlaceholder,
+                    options,
+                });
+            }
+            if (RANGE_LENGTH_MILES_HINT_RE.test(converted)) {
+                converted = mergeUnitRanges(converted, {
+                    unitSpec: UNITS.LENGTH.MILES,
+                    regex: RANGE_REGEXES.miles,
+                    converter: LENGTH_CONVERTERS.miles,
+                    formatter: formatLengthRange,
+                    addPlaceholder,
+                    options,
+                });
+            }
+            if (RANGE_LENGTH_YARDS_HINT_RE.test(converted)) {
+                converted = mergeUnitRanges(converted, {
+                    unitSpec: UNITS.LENGTH.YARDS,
+                    regex: RANGE_REGEXES.yards,
+                    converter: LENGTH_CONVERTERS.yards,
+                    formatter: formatLengthRange,
+                    addPlaceholder,
+                    options,
+                });
+            }
         }
 
         if (hasWeightUnits) {
@@ -328,78 +374,100 @@ function convertText(text) {
                 converter: WEIGHT_CONVERTER,
                 formatter: formatWeightRange,
                 addPlaceholder,
+                options,
             });
         }
 
         if (hasLiquidUnits) {
-            converted = mergeUnitRanges(converted, {
-                unitSpec: UNITS.LIQUID.CUPS,
-                regex: RANGE_REGEXES.cups,
-                converter: LIQUID_CONVERTERS.cups,
-                formatter: formatLiquidRange,
-                addPlaceholder,
-            });
-            converted = mergeUnitRanges(converted, {
-                unitSpec: UNITS.LIQUID.GALLONS,
-                regex: RANGE_REGEXES.gallons,
-                converter: LIQUID_CONVERTERS.gallons,
-                formatter: formatLiquidRange,
-                addPlaceholder,
-            });
-            converted = mergeUnitRanges(converted, {
-                unitSpec: UNITS.LIQUID.QUARTS,
-                regex: RANGE_REGEXES.quarts,
-                converter: LIQUID_CONVERTERS.quarts,
-                formatter: formatLiquidRange,
-                addPlaceholder,
-            });
-            converted = mergeUnitRanges(converted, {
-                unitSpec: UNITS.LIQUID.PINTS,
-                regex: RANGE_REGEXES.pints,
-                converter: LIQUID_CONVERTERS.pints,
-                formatter: formatLiquidRange,
-                addPlaceholder,
-            });
-            converted = mergeUnitRanges(converted, {
-                unitSpec: UNITS.LIQUID.FLOZ,
-                regex: RANGE_REGEXES.floz,
-                converter: LIQUID_CONVERTERS.floz,
-                formatter: formatLiquidRange,
-                addPlaceholder,
-            });
-            converted = mergeUnitRanges(converted, {
-                unitSpec: UNITS.LIQUID.TBSP,
-                regex: RANGE_REGEXES.tbsp,
-                converter: LIQUID_CONVERTERS.tbsp,
-                formatter: formatLiquidRange,
-                addPlaceholder,
-            });
-            converted = mergeUnitRanges(converted, {
-                unitSpec: UNITS.LIQUID.TSP,
-                regex: RANGE_REGEXES.tsp,
-                converter: LIQUID_CONVERTERS.tsp,
-                formatter: formatLiquidRange,
-                addPlaceholder,
-            });
+            if (RANGE_LIQUID_CUPS_HINT_RE.test(converted)) {
+                converted = mergeUnitRanges(converted, {
+                    unitSpec: UNITS.LIQUID.CUPS,
+                    regex: RANGE_REGEXES.cups,
+                    converter: LIQUID_CONVERTERS.cups,
+                    formatter: formatLiquidRange,
+                    addPlaceholder,
+                    options,
+                });
+            }
+            if (RANGE_LIQUID_GALLONS_HINT_RE.test(converted)) {
+                converted = mergeUnitRanges(converted, {
+                    unitSpec: UNITS.LIQUID.GALLONS,
+                    regex: RANGE_REGEXES.gallons,
+                    converter: LIQUID_CONVERTERS.gallons,
+                    formatter: formatLiquidRange,
+                    addPlaceholder,
+                    options,
+                });
+            }
+            if (RANGE_LIQUID_QUARTS_HINT_RE.test(converted)) {
+                converted = mergeUnitRanges(converted, {
+                    unitSpec: UNITS.LIQUID.QUARTS,
+                    regex: RANGE_REGEXES.quarts,
+                    converter: LIQUID_CONVERTERS.quarts,
+                    formatter: formatLiquidRange,
+                    addPlaceholder,
+                    options,
+                });
+            }
+            if (RANGE_LIQUID_PINTS_HINT_RE.test(converted)) {
+                converted = mergeUnitRanges(converted, {
+                    unitSpec: UNITS.LIQUID.PINTS,
+                    regex: RANGE_REGEXES.pints,
+                    converter: LIQUID_CONVERTERS.pints,
+                    formatter: formatLiquidRange,
+                    addPlaceholder,
+                    options,
+                });
+            }
+            if (RANGE_LIQUID_FLOZ_HINT_RE.test(converted)) {
+                converted = mergeUnitRanges(converted, {
+                    unitSpec: UNITS.LIQUID.FLOZ,
+                    regex: RANGE_REGEXES.floz,
+                    converter: LIQUID_CONVERTERS.floz,
+                    formatter: formatLiquidRange,
+                    addPlaceholder,
+                    options,
+                });
+            }
+            if (RANGE_LIQUID_TBSP_HINT_RE.test(converted)) {
+                converted = mergeUnitRanges(converted, {
+                    unitSpec: UNITS.LIQUID.TBSP,
+                    regex: RANGE_REGEXES.tbsp,
+                    converter: LIQUID_CONVERTERS.tbsp,
+                    formatter: formatLiquidRange,
+                    addPlaceholder,
+                    options,
+                });
+            }
+            if (RANGE_LIQUID_TSP_HINT_RE.test(converted)) {
+                converted = mergeUnitRanges(converted, {
+                    unitSpec: UNITS.LIQUID.TSP,
+                    regex: RANGE_REGEXES.tsp,
+                    converter: LIQUID_CONVERTERS.tsp,
+                    formatter: formatLiquidRange,
+                    addPlaceholder,
+                    options,
+                });
+            }
         }
     }
 
     if (AREA_HINT_RE.test(converted)) {
-        converted = convertAreaText(converted);
+        converted = convertAreaText(converted, options);
     }
     if (hasLengthUnits) {
-        converted = convertLengthText(converted);
+        converted = convertLengthText(converted, options);
     }
     if (hasLiquidUnits) {
         // needs to come before weight, since it will otherwise match "fl oz"
-        converted = convertLiquidText(converted);
+        converted = convertLiquidText(converted, options);
     }
     if (hasWeightUnits) {
-        converted = convertWeightText(converted);
+        converted = convertWeightText(converted, options);
     }
 
     if (AWG_HINT_RE.test(converted)) {
-        converted = convertAwgText(converted);
+        converted = convertAwgText(converted, options);
     }
 
     // Temperature ranges (Fahrenheit) - handle before individual conversions
@@ -412,11 +480,13 @@ function convertText(text) {
             const c1 = ((f1 - 32) * 5) / 9;
             const c2 = ((f2 - 32) * 5) / 9;
             const formatted = formatTemperatureRange(c1, c2);
-            return addPlaceholder(`${match} (${formatted}°C)`);
+            return addPlaceholder(
+                `${match} ${buildInsertedParenthetical(`${formatted}°C`, options)}`
+            );
         });
 
         // Then convert individual temperatures
-        converted = convertTemperatureText(converted);
+        converted = convertTemperatureText(converted, options);
     }
 
     // Restore placeholders (prevents inner tokens from being re-converted)
@@ -427,10 +497,18 @@ function convertText(text) {
     // Check for time zone expressions
     const hasTimeZone = RE_TIME_TEST.test(converted);
     if (hasTimeZone) {
-        converted = convertTimeZoneText(converted);
+        converted = convertTimeZoneText(converted, options);
     }
 
     return converted;
 }
 
-module.exports = { convertText, hasRelevantUnits };
+function convertText(text) {
+    return convertTextInternal(text, {});
+}
+
+function convertTextWithInsertMarkers(text) {
+    return convertTextInternal(text, { insertMarkers: true });
+}
+
+module.exports = { convertText, convertTextWithInsertMarkers, hasRelevantUnits };

--- a/src/exclusions/context.js
+++ b/src/exclusions/context.js
@@ -45,7 +45,10 @@ function hasCodeRelatedClass(classNames) {
 }
 
 function isContentEditableElement(node) {
-    if (!node || !node.getAttribute) return false;
+    if (!node) return false;
+    if (node.isContentEditable) return true;
+    if (!node.getAttribute) return false;
+    if (node.hasAttribute && !node.hasAttribute('contenteditable')) return false;
     const attr = node.getAttribute('contenteditable');
     if (!attr && attr !== '') return false;
     const normalized = String(attr).trim().toLowerCase();

--- a/src/units/area.js
+++ b/src/units/area.js
@@ -10,12 +10,13 @@ const { convertToDecimal } = require('../parsing/numbers.js');
 const { formatAreaMeasurement } = require('../formatting/units.js');
 const { inferResolutionFromValue } = require('../utils/precision.js');
 const { shouldExcludeMatch } = require('../exclusions/patterns.js');
+const { buildInsertedParenthetical } = require('../utils/insertMarkers.js');
 
 function shouldSkipMatch(match, offset, source) {
     return shouldExcludeMatch({ text: source, matchStart: offset, match });
 }
 
-function convertAreaText(text) {
+function convertAreaText(text, options = {}) {
     let converted = text;
     const lower = converted.toLowerCase();
 
@@ -77,7 +78,8 @@ function convertAreaText(text) {
                 if (Number.isNaN(n)) return match;
                 const sqm = n * factor;
                 const resolutionSquareMeters = inferResolutionFromValue(raw, factor);
-                return `${match} (${formatAreaMeasurement(sqm, { resolutionSquareMeters })})`;
+                const formatted = formatAreaMeasurement(sqm, { resolutionSquareMeters });
+                return `${match} ${buildInsertedParenthetical(formatted, options)}`;
             });
         }
     }

--- a/src/units/awg.js
+++ b/src/units/awg.js
@@ -1,6 +1,7 @@
 const { LENGTH_INCH_TO_METERS } = require('../utils/constants.js');
 const { formatLengthMeasurement } = require('../formatting/units.js');
 const { shouldExcludeMatch } = require('../exclusions/patterns.js');
+const { buildInsertedParenthetical } = require('../utils/insertMarkers.js');
 
 const AWG_REGEX = /(\d{1,3}(?:\.\d+)?)(?:\s*-\s*)?\s*AWG\b/gi;
 const AWG_RESOLUTION_METERS = 0.000001;
@@ -12,7 +13,7 @@ function convertAwgToMeters(gaugeValue) {
     return diameterInInches * LENGTH_INCH_TO_METERS;
 }
 
-function convertAwgText(text) {
+function convertAwgText(text, options = {}) {
     if (!text || typeof text !== 'string') return text;
     if (!/awg/i.test(text)) return text;
     AWG_REGEX.lastIndex = 0;
@@ -34,7 +35,7 @@ function convertAwgText(text) {
         const formatted = formatLengthMeasurement(meters, {
             resolutionMeters: AWG_RESOLUTION_METERS,
         });
-        return `${match} (${formatted})`;
+        return `${match} ${buildInsertedParenthetical(formatted, options)}`;
     });
 }
 

--- a/src/units/length.js
+++ b/src/units/length.js
@@ -17,7 +17,27 @@ const {
 } = require('../utils/precision.js');
 const { formatLengthMeasurement } = require('../formatting/units.js');
 const { shouldExcludeMatch } = require('../exclusions/patterns.js');
+const { buildInsertedParenthetical } = require('../utils/insertMarkers.js');
 const DOUBLE_APOSTROPHE_TOKENS = ["''", '’’'];
+
+const INCH_SYMBOL_CHARS = INCH_SYMBOLS.split('');
+const FEET_SYMBOL_CHARS = FEET_SYMBOLS.split('');
+
+const VALUE_PART = String.raw`(?:(?:\d{1,3}(?:,\d{3})+|\d+)\.\d+|(?:\d{1,3}(?:,\d{3})+|\d+)-\d+\/\d+|(?:\d{1,3}(?:,\d{3})+|\d+)\s+\d+\/\d+|\d+\/\d+|(?:\d{1,3}(?:,\d{3})+|\d+)[${UNICODE_FRACTIONS}]?|[${UNICODE_FRACTIONS}])`;
+const INCH_SYMBOL_TOKEN = String.raw`(?:''|’’|[${INCH_SYMBOLS}])`;
+
+const DIMENSION_REGEX = new RegExp(
+    String.raw`(${VALUE_PART})\s*${INCH_SYMBOL_TOKEN}?\s*[x×]\s*(${VALUE_PART})\s*${INCH_SYMBOL_TOKEN}(?!\s*\()`,
+    'giu'
+);
+const INCHES_SYMBOL_REGEX = new RegExp(
+    String.raw`(${VALUE_PART})\s*${INCH_SYMBOL_TOKEN}(?!\s*\()`,
+    'giu'
+);
+const FEET_SYMBOL_REGEX = new RegExp(
+    String.raw`(${VALUE_PART})\s*[${FEET_SYMBOLS}](?!['\u2019])(?!\s*\()(?!s)`,
+    'giu'
+);
 
 function containsDoubleApostrophes(text) {
     return DOUBLE_APOSTROPHE_TOKENS.some((token) => text.includes(token));
@@ -40,30 +60,14 @@ function convertLengthToMeters(feet = 0, inches = 0, miles = 0, yards = 0) {
     );
 }
 
-function convertLengthText(text) {
+function convertLengthText(text, options = {}) {
     let converted = text;
-    const VALUE_PART = String.raw`(?:(?:\d{1,3}(?:,\d{3})+|\d+)\.\d+|(?:\d{1,3}(?:,\d{3})+|\d+)-\d+\/\d+|(?:\d{1,3}(?:,\d{3})+|\d+)\s+\d+\/\d+|\d+\/\d+|(?:\d{1,3}(?:,\d{3})+|\d+)[${UNICODE_FRACTIONS}]?|[${UNICODE_FRACTIONS}])`;
-    const INCH_SYMBOL_TOKEN = String.raw`(?:''|’’|[${INCH_SYMBOLS}])`;
-
-    const dimensionRegex = new RegExp(
-        String.raw`(${VALUE_PART})\s*${INCH_SYMBOL_TOKEN}?\s*[x×]\s*(${VALUE_PART})\s*${INCH_SYMBOL_TOKEN}(?!\s*\()`,
-        'giu'
-    );
-
-    const inchesSymbolRegex = new RegExp(
-        String.raw`(${VALUE_PART})\s*${INCH_SYMBOL_TOKEN}(?!\s*\()`,
-        'giu'
-    );
-    const feetSymbolRegex = new RegExp(
-        String.raw`(${VALUE_PART})\s*[${FEET_SYMBOLS}](?!['\u2019])(?!\s*\()(?!s)`,
-        'giu'
-    );
 
     if (
-        INCH_SYMBOLS.split('').some((sym) => converted.includes(sym)) ||
+        INCH_SYMBOL_CHARS.some((sym) => converted.includes(sym)) ||
         containsDoubleApostrophes(converted)
     ) {
-        converted = converted.replace(dimensionRegex, function () {
+        converted = converted.replace(DIMENSION_REGEX, function () {
             const args = Array.from(arguments);
             const match = args[0];
             const value1 = args[1];
@@ -94,15 +98,16 @@ function convertLengthText(text) {
             const numericPart1 = formatted1.replace(/\s*(cm|mm|m|km)\s*$/i, '');
             const normalizedMatch = normalizeDoubleApostrophes(match);
 
-            return `${normalizedMatch} (${numericPart1}x${formatted2})`;
+            const formatted = `${numericPart1}x${formatted2}`;
+            return `${normalizedMatch} ${buildInsertedParenthetical(formatted, options)}`;
         });
     }
 
     if (
-        INCH_SYMBOLS.split('').some((sym) => converted.includes(sym)) ||
+        INCH_SYMBOL_CHARS.some((sym) => converted.includes(sym)) ||
         containsDoubleApostrophes(converted)
     ) {
-        converted = converted.replace(inchesSymbolRegex, function () {
+        converted = converted.replace(INCHES_SYMBOL_REGEX, function () {
             const args = Array.from(arguments);
             const match = args[0];
             const value = args[1];
@@ -115,13 +120,13 @@ function convertLengthText(text) {
             const meters = convertLengthToMeters(0, inches, 0);
             const resolutionMeters = inferResolutionMetersFromNumber(raw, 'in');
             const normalizedMatch = normalizeDoubleApostrophes(match);
-            const result = `${normalizedMatch} (${formatLengthMeasurement(meters, { resolutionMeters })})`;
-            return result;
+            const formatted = formatLengthMeasurement(meters, { resolutionMeters });
+            return `${normalizedMatch} ${buildInsertedParenthetical(formatted, options)}`;
         });
     }
 
-    if (FEET_SYMBOLS.split('').some((sym) => converted.includes(sym))) {
-        converted = converted.replace(feetSymbolRegex, function () {
+    if (FEET_SYMBOL_CHARS.some((sym) => converted.includes(sym))) {
+        converted = converted.replace(FEET_SYMBOL_REGEX, function () {
             const args = Array.from(arguments);
             const match = args[0];
             const value = args[1];
@@ -133,7 +138,8 @@ function convertLengthText(text) {
             if (Number.isNaN(feet)) return match;
             const meters = convertLengthToMeters(feet, 0, 0);
             const resolutionMeters = inferResolutionMetersFromNumber(raw, 'ft');
-            return `${match} (${formatLengthMeasurement(meters, { resolutionMeters })})`;
+            const formatted = formatLengthMeasurement(meters, { resolutionMeters });
+            return `${match} ${buildInsertedParenthetical(formatted, options)}`;
         });
     }
 
@@ -167,7 +173,8 @@ function convertLengthText(text) {
                 match,
                 UNITS.LENGTH.FEET_INCHES
             );
-            return `${match} (${formatLengthMeasurement(meters, { resolutionMeters })})`;
+            const formatted = formatLengthMeasurement(meters, { resolutionMeters });
+            return `${match} ${buildInsertedParenthetical(formatted, options)}`;
         });
     }
 
@@ -191,7 +198,8 @@ function convertLengthText(text) {
                 extractFirstValueToken(match),
                 'mi'
             );
-            return `${match} (${formatLengthMeasurement(meters, { resolutionMeters })})`;
+            const formatted = formatLengthMeasurement(meters, { resolutionMeters });
+            return `${match} ${buildInsertedParenthetical(formatted, options)}`;
         });
     }
 
@@ -215,7 +223,8 @@ function convertLengthText(text) {
                 extractFirstValueToken(match),
                 'yd'
             );
-            return `${match} (${formatLengthMeasurement(meters, { resolutionMeters })})`;
+            const formatted = formatLengthMeasurement(meters, { resolutionMeters });
+            return `${match} ${buildInsertedParenthetical(formatted, options)}`;
         });
     }
 

--- a/src/units/liquid.js
+++ b/src/units/liquid.js
@@ -13,12 +13,13 @@ const { inferResolutionFromParsedMeasurement } = require('../utils/precision.js'
 const { formatLiquidMeasurement } = require('../formatting/units.js');
 const { shouldExcludeMatch } = require('../exclusions/patterns.js');
 const { UNITS } = require('./index.js');
+const { buildInsertedParenthetical } = require('../utils/insertMarkers.js');
 
 function shouldSkipMatch(match, offset, source) {
     return shouldExcludeMatch({ text: source, matchStart: offset, match });
 }
 
-function convertLiquidText(text) {
+function convertLiquidText(text, options = {}) {
     let converted = text;
     const lower = converted.toLowerCase();
 
@@ -48,7 +49,8 @@ function convertLiquidText(text) {
                 primary: LIQUID_GALLON_TO_L,
                 secondary: LIQUID_QUART_TO_L,
             });
-            return `${match} (${formatLiquidMeasurement(liters, { resolutionLiters })})`;
+            const formatted = formatLiquidMeasurement(liters, { resolutionLiters });
+            return `${match} ${buildInsertedParenthetical(formatted, options)}`;
         });
     }
 
@@ -72,7 +74,8 @@ function convertLiquidText(text) {
                 primary: LIQUID_CUP_TO_L,
                 secondary: LIQUID_FLOZ_TO_L,
             });
-            return `${match} (${formatLiquidMeasurement(liters, { resolutionLiters })})`;
+            const formatted = formatLiquidMeasurement(liters, { resolutionLiters });
+            return `${match} ${buildInsertedParenthetical(formatted, options)}`;
         });
     }
 
@@ -101,7 +104,8 @@ function convertLiquidText(text) {
                 primary: LIQUID_TBSP_TO_L,
                 secondary: LIQUID_TSP_TO_L,
             });
-            return `${match} (${formatLiquidMeasurement(liters, { resolutionLiters })})`;
+            const formatted = formatLiquidMeasurement(liters, { resolutionLiters });
+            return `${match} ${buildInsertedParenthetical(formatted, options)}`;
         });
     }
 
@@ -120,7 +124,8 @@ function convertLiquidText(text) {
             const resolutionLiters = inferResolutionFromParsedMeasurement(parsed, {
                 primary: LIQUID_GALLON_TO_L,
             });
-            return `${match} (${formatLiquidMeasurement(liters, { resolutionLiters })})`;
+            const formatted = formatLiquidMeasurement(liters, { resolutionLiters });
+            return `${match} ${buildInsertedParenthetical(formatted, options)}`;
         });
     }
 
@@ -139,7 +144,8 @@ function convertLiquidText(text) {
             const resolutionLiters = inferResolutionFromParsedMeasurement(parsed, {
                 primary: LIQUID_QUART_TO_L,
             });
-            return `${match} (${formatLiquidMeasurement(liters, { resolutionLiters })})`;
+            const formatted = formatLiquidMeasurement(liters, { resolutionLiters });
+            return `${match} ${buildInsertedParenthetical(formatted, options)}`;
         });
     }
 
@@ -158,7 +164,8 @@ function convertLiquidText(text) {
             const resolutionLiters = inferResolutionFromParsedMeasurement(parsed, {
                 primary: LIQUID_PINT_TO_L,
             });
-            return `${match} (${formatLiquidMeasurement(liters, { resolutionLiters })})`;
+            const formatted = formatLiquidMeasurement(liters, { resolutionLiters });
+            return `${match} ${buildInsertedParenthetical(formatted, options)}`;
         });
     }
 

--- a/src/units/temperature.js
+++ b/src/units/temperature.js
@@ -1,14 +1,16 @@
 const { RE_TEMPERATURE_F } = require('../parsing/regex.js');
 const { inferResolutionFromValue } = require('../utils/precision.js');
 const { formatTemperatureCelsius } = require('../formatting/units.js');
+const { buildInsertedParenthetical } = require('../utils/insertMarkers.js');
 
-function convertTemperatureText(text) {
+function convertTemperatureText(text, options = {}) {
     return text.replace(RE_TEMPERATURE_F, (match, fStr) => {
         const f = parseFloat(fStr);
         if (Number.isNaN(f)) return match;
         const c = ((f - 32) * 5) / 9;
         const resolutionCelsius = inferResolutionFromValue(fStr, 5 / 9);
-        return `${match} (${formatTemperatureCelsius(c, { resolutionCelsius })}°C)`;
+        const formatted = `${formatTemperatureCelsius(c, { resolutionCelsius })}°C`;
+        return `${match} ${buildInsertedParenthetical(formatted, options)}`;
     });
 }
 

--- a/src/units/timezone.js
+++ b/src/units/timezone.js
@@ -1,5 +1,6 @@
 const { TIME_ZONE_OFFSETS } = require('../utils/constants.js');
 const { RE_TIME_GLOBAL } = require('../parsing/regex.js');
+const { buildInsertedParenthetical } = require('../utils/insertMarkers.js');
 
 const TARGET_TIMEZONE = 'PST';
 const TARGET_TIMEZONE_OFFSET = -8;
@@ -60,7 +61,7 @@ function convertTimeZone(timeStr, sourceTimezone, sourceOffset = null) {
     return `${targetHours}${formattedMinutes > 0 && formattedMinutes !== '00' ? `:${formattedMinutes}` : ''} ${targetAmPm}`;
 }
 
-function convertTimeZoneText(text) {
+function convertTimeZoneText(text, options = {}) {
     let converted = text;
     const timeRegex = RE_TIME_GLOBAL;
 
@@ -95,7 +96,8 @@ function convertTimeZoneText(text) {
         }
 
         const convertedTime = convertTimeZone(time, tz, offset);
-        return `${match} (${convertedTime} ${TARGET_TIMEZONE})`;
+        const formatted = `${convertedTime} ${TARGET_TIMEZONE}`;
+        return `${match} ${buildInsertedParenthetical(formatted, options)}`;
     });
 
     return converted;

--- a/src/units/weight.js
+++ b/src/units/weight.js
@@ -5,6 +5,7 @@ const { inferResolutionFromParsedMeasurement } = require('../utils/precision.js'
 const { formatWeightMeasurement } = require('../formatting/units.js');
 const { shouldExcludeMatch } = require('../exclusions/patterns.js');
 const { UNITS } = require('./index.js');
+const { buildInsertedParenthetical } = require('../utils/insertMarkers.js');
 
 function shouldSkipMatch(match, offset, source) {
     return shouldExcludeMatch({ text: source, matchStart: offset, match });
@@ -14,7 +15,7 @@ function convertWeightToGrams(pounds = 0, ounces = 0) {
     return pounds * WEIGHT_POUND_TO_GRAMS + ounces * WEIGHT_OUNCE_TO_GRAMS;
 }
 
-function convertWeightText(text) {
+function convertWeightText(text, options = {}) {
     let converted = text;
     const lower = converted.toLowerCase();
     if (
@@ -37,7 +38,8 @@ function convertWeightText(text) {
                 primary: WEIGHT_POUND_TO_GRAMS,
                 secondary: WEIGHT_OUNCE_TO_GRAMS,
             });
-            return `${match} (${formatWeightMeasurement(grams, { resolutionGrams })})`;
+            const formatted = formatWeightMeasurement(grams, { resolutionGrams });
+            return `${match} ${buildInsertedParenthetical(formatted, options)}`;
         });
     }
     return converted;

--- a/src/utils/insertMarkers.js
+++ b/src/utils/insertMarkers.js
@@ -1,0 +1,22 @@
+const INSERT_START = '\uE000';
+const INSERT_END = '\uE001';
+
+function buildInsertedParenthetical(text, options = {}) {
+    const content = String(text);
+    if (options.insertMarkers) {
+        return `(${INSERT_START}${content}${INSERT_END})`;
+    }
+    return `(${content})`;
+}
+
+function stripInsertMarkers(text) {
+    if (!text || typeof text !== 'string') return text;
+    return text.split(INSERT_START).join('').split(INSERT_END).join('');
+}
+
+module.exports = {
+    INSERT_START,
+    INSERT_END,
+    buildInsertedParenthetical,
+    stripInsertMarkers,
+};


### PR DESCRIPTION
• Performance

  - node scripts/run-perf.js now averages ~25.36 ms (target <30 ms
    hit).
  - Biggest win: src/converter.js now gates range-merging per unit
    variant (e.g. cups vs gallons) before calling mergeUnitRanges(),
    avoiding multiple full-string scans when that unit isn’t present.
  - src/content.js also avoids the slow jsdom TreeWalker path and uses
    a manual traversal + marker-based span insertion (src/utils/
    insertMarkers.js) instead of per-node diffing.

  AWG Early-Exit / Unified Pipeline

  - Global prefilter: src/content.js:231 skips conversion unless
    hasRelevantUnits(text) matches.
  - Category gate: src/converter.js:469 only calls convertAwgText()
    when /awg/i matches (same pattern is used to gate other unit
    converters).
  - Defensive early exit: src/units/awg.js:18 returns immediately if
    there’s no awg in the string.
  - Docs updated to prevent repeating this mistake (double-gate +
    range-merge gating): AGENTS.md:42.